### PR TITLE
Update chartjs and chartjs-node versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -131,50 +131,29 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chart.js": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.6.0.tgz",
-      "integrity": "sha1-MI+aSwv+1aFUwU9d6x2UcNIqvnE=",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.7.2.tgz",
+      "integrity": "sha512-90wl3V9xRZ8tnMvMlpcW+0Yg13BelsGS9P9t0ClaDxv/hdypHDr/YAGf+728m11P5ljwyB0ZHfPKCapZFqSqYA==",
       "requires": {
         "chartjs-color": "2.2.0",
-        "moment": "2.18.1"
-      },
-      "dependencies": {
-        "chartjs-color": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.2.0.tgz",
-          "integrity": "sha1-hKL7dVeH7YXDndbdjHsdiEKbrq4=",
-          "requires": {
-            "chartjs-color-string": "0.5.0",
-            "color-convert": "0.5.3"
-          },
-          "dependencies": {
-            "chartjs-color-string": {
-              "version": "0.5.0",
-              "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.5.0.tgz",
-              "integrity": "sha1-jTdS2Fgdhmh8Nb/iy4CsUhPOuME=",
-              "requires": {
-                "color-name": "1.1.3"
-              },
-              "dependencies": {
-                "color-name": {
-                  "version": "1.1.3",
-                  "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-                  "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-                }
-              }
-            },
-            "color-convert": {
-              "version": "0.5.3",
-              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-              "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
-            }
-          }
-        },
-        "moment": {
-          "version": "2.18.1",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-          "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
-        }
+        "moment": "2.21.0"
+      }
+    },
+    "chartjs-color": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.2.0.tgz",
+      "integrity": "sha1-hKL7dVeH7YXDndbdjHsdiEKbrq4=",
+      "requires": {
+        "chartjs-color-string": "0.5.0",
+        "color-convert": "0.5.3"
+      }
+    },
+    "chartjs-color-string": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.5.0.tgz",
+      "integrity": "sha512-amWNvCOXlOUYxZVDSa0YOab5K/lmEhbFNKI55PWc4mlv28BDzA7zaoQTGxSBgJMHIW+hGX8YUrvw/FH4LyhwSQ==",
+      "requires": {
+        "color-name": "1.1.3"
       }
     },
     "chartjs-node": {
@@ -968,6 +947,16 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
+    "color-convert": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+      "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
@@ -1752,6 +1741,11 @@
         "minimist": "0.0.8"
       }
     },
+    "moment": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -1986,14 +1980,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -2002,6 +1988,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chart-renderer",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A web service that renders Chart.js charts as static images",
   "main": "app.js",
   "scripts": {
@@ -18,8 +18,8 @@
   "homepage": "https://github.com/rebs-group/chart-renderer#readme",
   "dependencies": {
     "body-parser": "^1.18.2",
-    "chart.js": "^2.6.0",
-    "chartjs-node": "^1.6.0",
+    "chart.js": "^2.7.2",
+    "chartjs-node": "git://github.com/rebsgroup/chartjs-node#f97b875eb7cb432e85cbbd7da150dd79fd44bd0e",
     "express": "^4.16.1",
     "node-gyp": "^3.6.2"
   }


### PR DESCRIPTION
Waiting on https://github.com/vmpowerio/chartjs-node/pull/49 as well, hardcoded the commit as a dependency for now.